### PR TITLE
Upgrade to GoogleAds v19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "googleads/google-ads-php": "^17.0"
+        "googleads/google-ads-php": "^19.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/src/Adapters/AdapterAbstract.php
+++ b/src/Adapters/AdapterAbstract.php
@@ -3,12 +3,10 @@
 namespace JoelButcher\GoogleAds\Adapters;
 
 use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
-use Google\Ads\GoogleAds\Lib\V10\GoogleAdsClient as V10Client;
-use Google\Ads\GoogleAds\Lib\V10\GoogleAdsClientBuilder as V10ClientBuilder;
-use Google\Ads\GoogleAds\Lib\V8\GoogleAdsClient as V8Client;
-use Google\Ads\GoogleAds\Lib\V8\GoogleAdsClientBuilder as V8ClientBuilder;
-use Google\Ads\GoogleAds\Lib\V9\GoogleAdsClient as V9Client;
-use Google\Ads\GoogleAds\Lib\V9\GoogleAdsClientBuilder as V9ClientBuilder;
+use Google\Ads\GoogleAds\Lib\V12\GoogleAdsClient as V12Client;
+use Google\Ads\GoogleAds\Lib\V12\GoogleAdsClientBuilder as V12ClientBuilder;
+use Google\Ads\GoogleAds\Lib\V13\GoogleAdsClient as V13Client;
+use Google\Ads\GoogleAds\Lib\V13\GoogleAdsClientBuilder as V13ClientBuilder;
 use Google\Auth\FetchAuthTokenInterface;
 use JoelButcher\GoogleAds\Concerns\ValidatesConfig;
 use Psr\Log\LoggerInterface;
@@ -18,83 +16,24 @@ abstract class AdapterAbstract implements AdapterInterface
     use ValidatesConfig;
 
     /**
-     * The applications Client ID.
-     *
-     * @var string
-     */
-    private $clientId;
-
-    /**
-     * The applications Client Secret.
-     *
-     * @var string
-     */
-    private $clientSecret;
-
-    /**
-     * The applications Developer Token.
-     *
-     * @var string
-     */
-    private $developerToken;
-
-    /**
-     * The transport protocol used by the client.
-     *
-     * @var string
-     */
-    protected $transportProtocol = 'rest';
-
-    /**
-     * The minimum log level we should be logging.
-     *
-     * @var string
-     */
-    protected $logLevel = 'info';
-
-    /**
-     * The underlying logger implementation.
-     *
-     * @var LoggerInterface|null
-     */
-    protected $logger = null;
-
-    /**
      * Create a new adapter instance.
-     *
-     * @param  string|null  $clientId
-     * @param  string|null  $clientSecret
-     * @param  string|null  $developerToken
-     * @param  string  $transportProtocol
-     * @param  LoggerInterface|null  $logger
-     * @param  string  $logLevel
-     * @return void
      */
     public function __construct(
-        ?string $clientId = null,
-        ?string $clientSecret = null,
-        ?string $developerToken = null,
-        string $transportProtocol = 'rest',
-        ?LoggerInterface $logger = null,
-        string $logLevel = 'info'
+        private ?string $clientId = null,
+        private ?string $clientSecret = null,
+        private ?string $developerToken = null,
+        protected string $transportProtocol = 'rest',
+        protected ?LoggerInterface $logger = null,
+        protected string $logLevel = 'info'
     ) {
         $this->validateConfig($clientId, $clientSecret, $developerToken, $transportProtocol, $logLevel);
-        $this->clientId = $clientId;
-        $this->clientSecret = $clientSecret;
-        $this->developerToken = $developerToken;
-        $this->transportProtocol = $transportProtocol;
-        $this->logger = $logger;
-        $this->logLevel = strtoupper($logLevel);
+        $this->logLevel = strtoupper($this->logLevel);
     }
 
     /**
      * Build the Google Ads Client for the supported version.
-     *
-     * @param  string  $refreshToken
-     * @param  int|null  $loginCustomerId
-     * @return V8Client|V9Client|V10Client
      */
-    public function getClient(string $refreshToken, ?int $loginCustomerId = null)
+    public function getClient(string $refreshToken, ?int $loginCustomerId = null): V12Client|V13Client
     {
         $clientBuilder = $this->getClientBuilder()
             ->withDeveloperToken($this->developerToken)
@@ -115,16 +54,11 @@ abstract class AdapterAbstract implements AdapterInterface
 
     /**
      * Get the client builder used by the SDK adapter version.
-     *
-     * @return V8ClientBuilder|V9ClientBuilder|V10ClientBuilder
      */
-    abstract protected function getClientBuilder();
+    abstract protected function getClientBuilder(): V12ClientBuilder|V13ClientBuilder;
 
     /**
      * Get the OAuth2 Token builder for created a client builder.
-     *
-     * @param  string  $refreshToken
-     * @return FetchAuthTokenInterface
      */
     protected function getTokenBuilder(string $refreshToken): FetchAuthTokenInterface
     {

--- a/src/Adapters/AdapterFactory.php
+++ b/src/Adapters/AdapterFactory.php
@@ -2,7 +2,6 @@
 
 namespace JoelButcher\GoogleAds\Adapters;
 
-use JoelButcher\GoogleAds\ConfigException;
 use JoelButcher\GoogleAds\SupportedVersions;
 use ReflectionClass;
 
@@ -10,12 +9,6 @@ final class AdapterFactory
 {
     /**
      * Build a new Adapter instance for the given SDK version and config array.
-     *
-     * @param  int  $sdkVersion
-     * @param  array  $config
-     * @return AdapterInterface
-     *
-     * @throws ConfigException
      */
     public static function build(int $sdkVersion, array $config = []): AdapterInterface
     {

--- a/src/Adapters/AdapterInterface.php
+++ b/src/Adapters/AdapterInterface.php
@@ -2,18 +2,13 @@
 
 namespace JoelButcher\GoogleAds\Adapters;
 
-use Google\Ads\GoogleAds\Lib\V10\GoogleAdsClient as V10Client;
-use Google\Ads\GoogleAds\Lib\V8\GoogleAdsClient as V8Client;
-use Google\Ads\GoogleAds\Lib\V9\GoogleAdsClient as V9Client;
+use Google\Ads\GoogleAds\Lib\V12\GoogleAdsClient as V12Client;
+use Google\Ads\GoogleAds\Lib\V13\GoogleAdsClient as V13Client;
 
 interface AdapterInterface
 {
     /**
      * Build the Google Ads Client for the supported version.
-     *
-     * @param  string  $refreshToken
-     * @param  int|null  $loginCustomerId
-     * @return V8Client|V9Client|V10Client
      */
-    public function getClient(string $refreshToken, ?int $loginCustomerId = null);
+    public function getClient(string $refreshToken, ?int $loginCustomerId = null): V12Client|V13Client;
 }

--- a/src/Adapters/V12/Adapter.php
+++ b/src/Adapters/V12/Adapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace JoelButcher\GoogleAds\Adapters\V10;
+namespace JoelButcher\GoogleAds\Adapters\V12;
 
-use Google\Ads\GoogleAds\Lib\V10\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V12\GoogleAdsClientBuilder;
 use JoelButcher\GoogleAds\Adapters\AdapterAbstract;
 
 class Adapter extends AdapterAbstract

--- a/src/Adapters/V13/Adapter.php
+++ b/src/Adapters/V13/Adapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace JoelButcher\GoogleAds\Adapters\V11;
+namespace JoelButcher\GoogleAds\Adapters\V13;
 
-use Google\Ads\GoogleAds\Lib\V11\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V13\GoogleAdsClientBuilder;
 use JoelButcher\GoogleAds\Adapters\AdapterAbstract;
 
 class Adapter extends AdapterAbstract

--- a/src/Concerns/ThrowsConfigException.php
+++ b/src/Concerns/ThrowsConfigException.php
@@ -8,11 +8,6 @@ trait ThrowsConfigException
 {
     /**
      * Throws a config exception for the given message.
-     *
-     * @param  string  $message
-     * @return void
-     *
-     * @throws ConfigException
      */
     protected static function throwNewConfigException(string $message): void
     {

--- a/src/Concerns/ValidatesConfig.php
+++ b/src/Concerns/ValidatesConfig.php
@@ -2,7 +2,6 @@
 
 namespace JoelButcher\GoogleAds\Concerns;
 
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 trait ValidatesConfig
@@ -11,14 +10,6 @@ trait ValidatesConfig
 
     /**
      * Validate the given config items.
-     *
-     * @param  string|null  $clientId
-     * @param  string|null  $clientSecret
-     * @param  string|null  $developerToken
-     * @param  string  $transportProtocol
-     * @param  LoggerInterface|null  $logger
-     * @param  string  $logLevel
-     * @return void
      */
     protected static function validateConfig(
         ?string $clientId = null,

--- a/src/SupportedVersions.php
+++ b/src/SupportedVersions.php
@@ -4,8 +4,8 @@ namespace JoelButcher\GoogleAds;
 
 final class SupportedVersions
 {
-    public const VERSION_10 = 10;
-    public const VERSION_11 = 11;
+    public const VERSION_12 = 12;
+    public const VERSION_13 = 13;
 
     /**
      * Get the list of all supported version.
@@ -15,8 +15,8 @@ final class SupportedVersions
     public static function getAllVersions(): array
     {
         return [
-            self::VERSION_10,
-            self::VERSION_11,
+            self::VERSION_12,
+            self::VERSION_13,
         ];
     }
 }

--- a/tests/Fixtures/Adapter.php
+++ b/tests/Fixtures/Adapter.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Fixtures;
 
-use Google\Ads\GoogleAds\Lib\V9\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V12\GoogleAdsClientBuilder;
 use JoelButcher\GoogleAds\Adapters\AdapterAbstract;
 
 class Adapter extends AdapterAbstract

--- a/tests/Unit/Adapters/AdapterFactoryTest.php
+++ b/tests/Unit/Adapters/AdapterFactoryTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Adapters;
 
 use JoelButcher\GoogleAds\Adapters\AdapterFactory;
-use JoelButcher\GoogleAds\Adapters\V10\Adapter as V10Adapter;
-use JoelButcher\GoogleAds\Adapters\V11\Adapter as V11Adapter;
+use JoelButcher\GoogleAds\Adapters\V12\Adapter as V12Adapter;
+use JoelButcher\GoogleAds\Adapters\V13\Adapter as V13Adapter;
 use JoelButcher\GoogleAds\SupportedVersions;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\HasDefaultConfig;
@@ -33,10 +33,10 @@ class AdapterFactoryTest extends TestCase
         $factory = new AdapterFactory;
         $config = $this->getDefaultConfig();
 
-        $v10Adapter = $factory->build(SupportedVersions::VERSION_10, $config);
-        $this->assertInstanceOf(V10Adapter::class, $v10Adapter);
+        $v10Adapter = $factory->build(SupportedVersions::VERSION_12, $config);
+        $this->assertInstanceOf(V12Adapter::class, $v10Adapter);
 
-        $v11Adapter = $factory->build(SupportedVersions::VERSION_11, $config);
-        $this->assertInstanceOf(V11Adapter::class, $v11Adapter);
+        $v11Adapter = $factory->build(SupportedVersions::VERSION_13, $config);
+        $this->assertInstanceOf(V13Adapter::class, $v11Adapter);
     }
 }

--- a/tests/Unit/Adapters/V12/AdapterTest.php
+++ b/tests/Unit/Adapters/V12/AdapterTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Unit\Adapters\V10;
+namespace Tests\Unit\Adapters\V12;
 
-use Google\Ads\GoogleAds\Lib\V10\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V12\GoogleAdsClient;
 use JoelButcher\GoogleAds\Adapters\AdapterFactory;
 use JoelButcher\GoogleAds\Adapters\AdapterInterface;
 use JoelButcher\GoogleAds\ConfigException;
@@ -92,7 +92,7 @@ class AdapterTest extends TestCase
         $factory = new AdapterFactory;
 
         return $factory->build(
-            SupportedVersions::VERSION_10,
+            SupportedVersions::VERSION_12,
             ! is_null($config) ? $config : $this->getDefaultConfig()
         );
     }

--- a/tests/Unit/Adapters/V13/AdapterTest.php
+++ b/tests/Unit/Adapters/V13/AdapterTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Unit\Adapters\V11;
+namespace Tests\Unit\Adapters\V13;
 
-use Google\Ads\GoogleAds\Lib\V11\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V13\GoogleAdsClient;
 use JoelButcher\GoogleAds\Adapters\AdapterFactory;
 use JoelButcher\GoogleAds\Adapters\AdapterInterface;
 use JoelButcher\GoogleAds\ConfigException;
@@ -92,7 +92,7 @@ class AdapterTest extends TestCase
         $factory = new AdapterFactory;
 
         return $factory->build(
-            SupportedVersions::VERSION_11,
+            SupportedVersions::VERSION_13,
             ! is_null($config) ? $config : $this->getDefaultConfig()
         );
     }

--- a/tests/Unit/GoogleAdsTest.php
+++ b/tests/Unit/GoogleAdsTest.php
@@ -2,18 +2,18 @@
 
 namespace Tests\Unit;
 
-use Google\Ads\GoogleAds\V10\Services\AccountLinkServiceClient as V10AccountLinkServiceClient;
-use Google\Ads\GoogleAds\V10\Services\AdGroupServiceClient as V10AdGroupServiceClient;
-use Google\Ads\GoogleAds\V10\Services\AdServiceClient as V10AdServiceClient;
-use Google\Ads\GoogleAds\V10\Services\CampaignServiceClient as V10CampaignServiceClient;
-use Google\Ads\GoogleAds\V10\Services\KeywordPlanAdGroupServiceClient as V10KeywordPlanAdGroupServiceClient;
-use Google\Ads\GoogleAds\V10\Services\KeywordPlanCampaignServiceClient as V10KeywordPlanCampaignServiceClient;
-use Google\Ads\GoogleAds\V11\Services\AccountLinkServiceClient as V11AccountLinkServiceClient;
-use Google\Ads\GoogleAds\V11\Services\AdGroupServiceClient as V11AdGroupServiceClient;
-use Google\Ads\GoogleAds\V11\Services\AdServiceClient as V11AdServiceClient;
-use Google\Ads\GoogleAds\V11\Services\CampaignServiceClient as V11CampaignServiceClient;
-use Google\Ads\GoogleAds\V11\Services\KeywordPlanAdGroupServiceClient as V11KeywordPlanAdGroupServiceClient;
-use Google\Ads\GoogleAds\V11\Services\KeywordPlanCampaignServiceClient as V11KeywordPlanCampaignServiceClient;
+use Google\Ads\GoogleAds\V12\Services\AccountLinkServiceClient as V12AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V12\Services\AdGroupServiceClient as V12AdGroupServiceClient;
+use Google\Ads\GoogleAds\V12\Services\AdServiceClient as V12AdServiceClient;
+use Google\Ads\GoogleAds\V12\Services\CampaignServiceClient as V12CampaignServiceClient;
+use Google\Ads\GoogleAds\V12\Services\KeywordPlanAdGroupServiceClient as V12KeywordPlanAdGroupServiceClient;
+use Google\Ads\GoogleAds\V12\Services\KeywordPlanCampaignServiceClient as V12KeywordPlanCampaignServiceClient;
+use Google\Ads\GoogleAds\V13\Services\AccountLinkServiceClient as V13AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V13\Services\AdGroupServiceClient as V13AdGroupServiceClient;
+use Google\Ads\GoogleAds\V13\Services\AdServiceClient as V13AdServiceClient;
+use Google\Ads\GoogleAds\V13\Services\CampaignServiceClient as V13CampaignServiceClient;
+use Google\Ads\GoogleAds\V13\Services\KeywordPlanAdGroupServiceClient as V13KeywordPlanAdGroupServiceClient;
+use Google\Ads\GoogleAds\V13\Services\KeywordPlanCampaignServiceClient as V13KeywordPlanCampaignServiceClient;
 use JoelButcher\GoogleAds\GoogleAds;
 use JoelButcher\GoogleAds\GoogleAdsException;
 use JoelButcher\GoogleAds\SupportedVersions;
@@ -78,120 +78,120 @@ class GoogleAdsTest extends TestCase
     /**
      * @test
      */
-    public function itCanRetrieveV10AccountLinkServiceClient()
+    public function itCanRetrieveV12AccountLinkServiceClient()
     {
-        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_10]));
+        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_12]));
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V10AccountLinkServiceClient::class, $googleAds->getAccountLinkServiceClient());
+        $this->assertInstanceOf(V12AccountLinkServiceClient::class, $googleAds->getAccountLinkServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV10CampaignServiceClient()
+    public function itCanRetrieveV12CampaignServiceClient()
     {
-        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_10]));
+        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_12]));
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V10CampaignServiceClient::class, $googleAds->getCampaignServiceClient());
+        $this->assertInstanceOf(V12CampaignServiceClient::class, $googleAds->getCampaignServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV10AdGroupServiceClient()
+    public function itCanRetrieveV12AdGroupServiceClient()
     {
-        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_10]));
+        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_12]));
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V10AdGroupServiceClient::class, $googleAds->getAdGroupServiceClient());
+        $this->assertInstanceOf(V12AdGroupServiceClient::class, $googleAds->getAdGroupServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV10AdServiceClient()
+    public function itCanRetrieveV12AdServiceClient()
     {
-        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_10]));
+        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_12]));
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V10AdServiceClient::class, $googleAds->getAdServiceClient());
+        $this->assertInstanceOf(V12AdServiceClient::class, $googleAds->getAdServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV10KeywordPlanCampaignServiceClient()
+    public function itCanRetrieveV12KeywordPlanCampaignServiceClient()
     {
-        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_10]));
+        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_12]));
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V10KeywordPlanCampaignServiceClient::class, $googleAds->getKeywordPlanCampaignServiceClient());
+        $this->assertInstanceOf(V12KeywordPlanCampaignServiceClient::class, $googleAds->getKeywordPlanCampaignServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV10KeywordPlanAdGroupServiceClient()
+    public function itCanRetrieveV12KeywordPlanAdGroupServiceClient()
     {
-        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_10]));
+        $googleAds = new GoogleAds(...array_merge($this->getDefaultConfig(), [SupportedVersions::VERSION_12]));
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V10KeywordPlanAdGroupServiceClient::class, $googleAds->getKeywordPlanAdGroupServiceClient());
+        $this->assertInstanceOf(V12KeywordPlanAdGroupServiceClient::class, $googleAds->getKeywordPlanAdGroupServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV11AccountLinkServiceClient()
+    public function itCanRetrieveV13AccountLinkServiceClient()
     {
         $googleAds = new GoogleAds(...$this->getDefaultConfig());
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V11AccountLinkServiceClient::class, $googleAds->getAccountLinkServiceClient());
+        $this->assertInstanceOf(V13AccountLinkServiceClient::class, $googleAds->getAccountLinkServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV11CampaignServiceClient()
+    public function itCanRetrieveV13CampaignServiceClient()
     {
         $googleAds = new GoogleAds(...$this->getDefaultConfig());
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V11CampaignServiceClient::class, $googleAds->getCampaignServiceClient());
+        $this->assertInstanceOf(V13CampaignServiceClient::class, $googleAds->getCampaignServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV11AdGroupServiceClient()
+    public function itCanRetrieveV13AdGroupServiceClient()
     {
         $googleAds = new GoogleAds(...$this->getDefaultConfig());
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V11AdGroupServiceClient::class, $googleAds->getAdGroupServiceClient());
+        $this->assertInstanceOf(V13AdGroupServiceClient::class, $googleAds->getAdGroupServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV11AdServiceClient()
+    public function itCanRetrieveV13AdServiceClient()
     {
         $googleAds = new GoogleAds(...$this->getDefaultConfig());
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V11AdServiceClient::class, $googleAds->getAdServiceClient());
+        $this->assertInstanceOf(V13AdServiceClient::class, $googleAds->getAdServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV11KeywordPlanCampaignServiceClient()
+    public function itCanRetrieveV13KeywordPlanCampaignServiceClient()
     {
         $googleAds = new GoogleAds(...$this->getDefaultConfig());
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V11KeywordPlanCampaignServiceClient::class, $googleAds->getKeywordPlanCampaignServiceClient());
+        $this->assertInstanceOf(V13KeywordPlanCampaignServiceClient::class, $googleAds->getKeywordPlanCampaignServiceClient());
     }
 
     /**
      * @test
      */
-    public function itCanRetrieveV11KeywordPlanAdGroupServiceClient()
+    public function itCanRetrieveV13KeywordPlanAdGroupServiceClient()
     {
         $googleAds = new GoogleAds(...$this->getDefaultConfig());
         $googleAds->authorize('token', 12345678);
-        $this->assertInstanceOf(V11KeywordPlanAdGroupServiceClient::class, $googleAds->getKeywordPlanAdGroupServiceClient());
+        $this->assertInstanceOf(V13KeywordPlanAdGroupServiceClient::class, $googleAds->getKeywordPlanAdGroupServiceClient());
     }
 }


### PR DESCRIPTION
## TL;DR
This PR aligns this package with the latest [googleads/google-ads-php ](https://github.com/googleads/google-ads-php) v19 release. 

## Explanation
- Removes support for V10 & V11
- Adds adapters & tests for V12 and V13
- Updates PHP syntax across the package to use PHP 8 syntax
  - Constructor Property Promotion
  - Added types, including mixed types
- Updated CI tests to include PHP 8.2